### PR TITLE
Fix lint step failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,7 @@ runs:
       - name: Lint
         shell: bash -l {0}
         run: |
+          set -euo pipefail
           snakefmt --check ${{ inputs.snakefmt-directory }}
           echo "Linted snakefiles: ${{ inputs.snakefmt-directory }}" >> $GITHUB_STEP_SUMMARY
           black --check --diff ${{ inputs.black-directory }}


### PR DESCRIPTION
## Summary
- ensure the lint step stops the workflow when `snakefmt` or `black` fail

## Testing
- `git show -U0 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68644d42cd588323abddd363bd2713b9