### PR TITLE
Revert "Add pytest step for extension scripts directory with exit code handling"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,37 +61,6 @@ runs:
               sunbeam extend https://github.com/$i
           done
 
-      - name: Run extension scripts tests
-        shell: bash -l {0}
-        run: |
-          # Run pytest only against the extension's scripts directory.
-          # Do not use set -e so we can inspect pytest's exit code and act accordingly.
-          TARGET="${GITHUB_WORKSPACE}/scripts"
-
-          if [ ! -d "$TARGET" ]; then
-            echo "No scripts directory at $TARGET" >> $GITHUB_STEP_SUMMARY
-            exit 0
-          fi
-
-          # Run pytest and capture exit code. Allow pytest to return non-zero without killing the script.
-          pytest -q "$TARGET"
-          rc=$?
-          true
-
-          if [ "$rc" -eq 0 ]; then
-            echo "Extension scripts tests passed (rc=0)" >> $GITHUB_STEP_SUMMARY
-            exit 0
-          elif [ "$rc" -eq 1 ]; then
-            echo "Extension scripts tests failed (rc=1)" >> $GITHUB_STEP_SUMMARY
-            exit 1
-          elif [ "$rc" -eq 4 ] || [ "$rc" -eq 5 ]; then
-            echo "No extension scripts tests found (pytest rc=${rc}) — continuing" >> $GITHUB_STEP_SUMMARY
-            exit 0
-          else
-            echo "pytest exited with unexpected code ${rc} — failing step" >> $GITHUB_STEP_SUMMARY
-            exit $rc
-          fi
-
       - name: Lint
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Reverts sunbeam-labs/sbx_test_action#10

These will naturally be run inside of snakemake-managed environments and we don't want to deal with automating that in tests. If people want to run this in addition 